### PR TITLE
fix compiled file name bug

### DIFF
--- a/src/grpc_lib_compile.erl
+++ b/src/grpc_lib_compile.erl
@@ -41,7 +41,7 @@ file(Filename, Options) ->
 
 compile_pb(Filename, Options) ->
     ok = gpb_compile:file(Filename, [maps | Options ++ [{i, "."}]]),
-    CompiledPB =  filename:rootname(Filename) ++ ".erl",
+    CompiledPB = gpb_names:file_name_to_module_name(Filename, Options),
     GpbInludeDir = filename:join(code:lib_dir(gpb), "include"),
     {ok, Module, Compiled} = compile:file(CompiledPB, 
                                           [binary, {i, GpbInludeDir}]),


### PR DESCRIPTION
* gpb has some options to change the file name of the output source code.
* For example, you can get `somefile_pb.erl` or `pb_otherfile.erl` by specifying `{module_name_suffix, "_pb"}` or `{module_name_prefix, "pb_"}`.
* By using `gpb_names:file_name_to_module_name()` you can get a file name that respects these settings.