### PR TITLE
Compiled file path

### DIFF
--- a/src/grpc_lib_compile.erl
+++ b/src/grpc_lib_compile.erl
@@ -41,7 +41,7 @@ file(Filename, Options) ->
 
 compile_pb(Filename, Options) ->
     ok = gpb_compile:file(Filename, [maps | Options ++ [{i, "."}]]),
-    CompiledPB =  filename:rootname(Filename) ++ ".erl",
+    CompiledPB = gpb_names:file_name_to_module_name(Filename, Options),
     GpbInludeDir = filename:join(code:lib_dir(gpb), "include"),
     {ok, Module, Compiled} = compile:file(CompiledPB, 
                                           [binary, {i, GpbInludeDir}]),


### PR DESCRIPTION
* I made a [rebar3 plugin using grpc_lib](https://github.com/ajiyoshi-vg/grpc_plugin).
* It's almost the same as [rebar3 gpb plugin](https://github.com/lrascao/rebar3_gpb_plugin) but it uses grpc_lib to automatically generate code for grpc.
* gpb has some options to change the file name/directory of the output source code.
  * For example, you can specify `{module_name_suffix, "_pb"}` or `{module_name_prefix, "pb_"}`, then get `pb_something.erl` or `other_pb.erl` 
  * or just `{o, "dir"}`  to specify output directory
* These options of gpb will be respected by this pull request.
